### PR TITLE
Fix bug when writing uint24Be

### DIFF
--- a/Libraries/Raknet/Helper.cs
+++ b/Libraries/Raknet/Helper.cs
@@ -22,7 +22,7 @@ namespace ConMaster.Raknet
         {
             buffer[2] = (byte)value;
             buffer[1] = (byte)(value >> 8);
-            buffer[1] = (byte)(value >> 16);
+            buffer[0] = (byte)(value >> 16);
             return 3;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
when writing uint24BE it was copying the second byte twice 